### PR TITLE
Creating npm, bower and yarn task

### DIFF
--- a/generators/package-manager/templates/grunt/aliases.js
+++ b/generators/package-manager/templates/grunt/aliases.js
@@ -1,0 +1,12 @@
+module.exports = {
+  default: [],
+  bower: [
+    'auto_install:bower-install',
+  ],
+  npm: [
+    'auto_install:npm-install',
+  ],
+  yarn: [
+    'shell:yarn',
+  ],
+};

--- a/generators/package-manager/templates/grunt/auto_install.js
+++ b/generators/package-manager/templates/grunt/auto_install.js
@@ -1,0 +1,19 @@
+module.exports = {
+  'npm-install': {
+    options: {
+      stdout: true,
+      stderr: true,
+      failOnError: true,
+      bower: false,
+      npm: true,
+    },
+  },
+  'bower-install': {
+    options: {
+      stderr: false,
+      failOnError: false,
+      npm: false,
+      bower: '--allow-root',
+    },
+  },
+};

--- a/generators/package-manager/templates/grunt/shell.js
+++ b/generators/package-manager/templates/grunt/shell.js
@@ -1,0 +1,5 @@
+module.exports = {
+  yarn: {
+    command: 'yarn install',
+  },
+};


### PR DESCRIPTION
For the installing npm packages , bower packages and yarn packages so we need the plugins `grunt-auto-install` and `grunt-shell`.