### PR TITLE
grunt task for browserify

### DIFF
--- a/generators/browserify/index.js
+++ b/generators/browserify/index.js
@@ -1,0 +1,56 @@
+const yeoman = require('yeoman-generator');
+const yosay = require('yosay');
+const _merge = require('lodash/merge');
+const _includes = require('lodash/includes');
+
+module.exports = yeoman.Base.extend({
+  prompting: {
+    browserify() {
+      const self = this;
+
+      this.log(yosay(
+        'Installing Browserify using create Bundle'
+      ));
+      return this.prompt([{
+        type: 'input',
+        name: 'bundleFile',
+        message: 'which created bundle file?',
+        default: 'src/main.js',
+        when: () => !self.config.get('bundleFile'),
+      }])
+      .then(answers => {
+        self.bundleFile = self.config.get('bundleFile') || answers.bundleFile;
+      });
+    },
+  },
+  writing() {
+    // Read a package.json if it exists or create it
+    const packageJSON = this.fs.readJSON(this.destinationPath('package.json'), {});
+
+    // Read a aliases.js if it exists or create it
+    let aliasesJS = require(this.destinationPath('./grunt/aliases.js'));
+    // CodeCept
+    this.log('Configuring for Browserify');
+    // Convert JSON to an indented JS module.
+    aliasesJS = 'module.exports=' + JSON.stringify(_merge(aliasesJS, {
+      default: [],
+      bundle: [
+        'browserify',
+      ],
+    }), null, 2);
+    _merge(packageJSON, {
+      devDependencies: {
+        'grunt-browserify': '^5.0.0',
+      },
+    });
+    this.fs.write(this.destinationPath('grunt/aliases.js'), aliasesJS);
+    this.fs.copyTpl(
+         this.templatePath('grunt/browserify.js'),
+         this.destinationPath('./grunt/browserify.js'),
+         { fileName: this.bundleFile }
+       );
+    this.log('Writing to package.json');
+    this.fs.writeJSON(this.destinationPath('package.json'), packageJSON);
+    this.installDependencies();
+  },
+});

--- a/generators/browserify/templates/grunt/aliases.js
+++ b/generators/browserify/templates/grunt/aliases.js
@@ -1,0 +1,6 @@
+module.exports = {
+  default: [],
+  bundle: [
+    'browserify',
+  ],
+};

--- a/generators/browserify/templates/grunt/browserify.js
+++ b/generators/browserify/templates/grunt/browserify.js
@@ -1,0 +1,13 @@
+module.exports = {
+  browserify: {
+    options: {
+      debug: true,
+      sourceMaps: true,
+      verbose: true,
+      keepAlive: true,
+    },
+    files: {
+      'dist/bundle.js': 'main.js',
+    },
+  },
+};

--- a/generators/browserify/templates/grunt/browserify.js
+++ b/generators/browserify/templates/grunt/browserify.js
@@ -7,7 +7,7 @@ module.exports = {
       keepAlive: true,
     },
     files: {
-      'dist/bundle.js': 'main.js',
+      'dist/bundle.js': '<%= fileName %>',
     },
   },
 };


### PR DESCRIPTION
Create the grunt task for browserify so we need the `grunt-browserify` plugin follow the reference (https://www.npmjs.com/package/grunt-browserify) plugin. For the transforms we use the `coffeeify` for the coffeescript files , ` tsify or typescriptifier`  for the typescript file and  `envify`  for the set environment.